### PR TITLE
Prepare v1.0.0 for npm publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,21 @@
+# Source and tests are not needed in the published package
+# (dist/ and src/ are included via the "files" field in package.json)
+test/
+coverage/
+*.test.ts
+*.test.tsx
+*.spec.ts
+*.spec.tsx
+
+# Config files
+.github/
+.husky/
+tsconfig.json
+yarn.lock
+package-lock.json
+.eslintrc*
+.prettierrc*
+
+# Misc
+.DS_Store
+*.log

--- a/README.md
+++ b/README.md
@@ -1,67 +1,140 @@
 # react-hook-filters
 
-react custom hook to handle filters in web apps (set, get) data from search params and more..
+A headless React hook for managing filter state in dashboards and data tables. Handles the common pattern of filter forms above tables — submit, reset, and optionally sync the filter state with URL search parameters so users get the same results after a page refresh.
+
+## Features
+
+- **Headless** — no UI, just state and handlers you wire up yourself
+- **URL sync** — persist filters in the URL so page refresh restores them (optional)
+- **Type-safe** — fully generic TypeScript types inferred from your filter shape
+- **Stable references** — all returned functions are memoized with `useCallback`
+- **Callbacks** — `onSubmit` and `onReset` hooks for triggering data fetches
+- **Lightweight** — no dependencies beyond `history`
 
 ## Installation
 
-### npm
-
 ```bash
 npm install react-hook-filters
-```
-
-### yarn
-
-```bash
+# or
 yarn add react-hook-filters
 ```
 
-## Usage
+## Quick Start
 
-```jsx
-import useFilters from 'react-hook-filter';
+```tsx
+import useFilters from 'react-hook-filters';
 
 const initialFilters = { name: '', age: '', gender: '' };
 
-const Home = ({ ...props }) => {
-  const { filters, changeFilters, resetFilters, submitFilters } = useFilters({
+function UsersTable() {
+  const {
+    filters,
+    changeFilters,
+    resetFilters,
+    submitFilters,
+    hasActiveFilters,
+    getActiveFilterCount,
+  } = useFilters({
     initialFilters,
+    onSubmit: (filters) => fetchUsers(filters), // called on submitFilters()
+    onReset: () => fetchUsers({}),              // called on resetFilters()
   });
 
-  const handleSubmit = (e: any) => {
-    e.preventDefault();
-    submitFilters(); //this will append filters to search params
-  };
   return (
-    <div className={styles.Home}>
-      <form onSubmit={handleSubmit}>
+    <div>
+      <form onSubmit={(e) => { e.preventDefault(); submitFilters(); }}>
         <input
-          placeholder="name"
+          placeholder="Name"
           value={filters.name}
-          type="text"
-          onChange={e => changeFilters('name', e.target.value)}
+          onChange={(e) => changeFilters('name', e.target.value)}
         />
-        <select onChange={e => changeFilters('gender', e.target.value)}>
-          <option value="male">male</option>
-          <option value="female">female</option>
+        <select onChange={(e) => changeFilters('gender', e.target.value)}>
+          <option value="">All</option>
+          <option value="male">Male</option>
+          <option value="female">Female</option>
         </select>
         <input
-          placeholder="age"
+          placeholder="Age"
           value={filters.age}
           type="number"
-          onChange={e => changeFilters('age', e.target.value)}
+          onChange={(e) => changeFilters('age', e.target.value)}
         />
 
-        <button type="submit">submit</button>
-        <button onClick={resetFilters}>reset</button>
+        <button type="submit">Apply filters</button>
+        {hasActiveFilters && (
+          <button type="button" onClick={resetFilters}>
+            Reset ({getActiveFilterCount()})
+          </button>
+        )}
       </form>
+
+      {/* your table here */}
     </div>
   );
-};
+}
+```
 
-export default Home;
+## API
+
+### `useFilters(options)`
+
+#### Options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `initialFilters` | `T` | required | Object defining the filter shape and default values |
+| `syncWithUrl` | `boolean` | `true` | Sync filter state with URL search params |
+| `onSubmit` | `(filters: T) => void` | — | Called when `submitFilters()` is invoked |
+| `onReset` | `(filters: T) => void` | — | Called when `resetFilters()` is invoked |
+
+#### Returns
+
+| Property | Type | Description |
+|---|---|---|
+| `filters` | `T` | Current filter values |
+| `changeFilters` | `(name: keyof T, value) => void` | Update a single filter |
+| `setMultipleFilters` | `(partial: Partial<T>) => void` | Update multiple filters at once |
+| `submitFilters` | `() => void` | Apply filters — updates URL and calls `onSubmit` |
+| `resetFilters` | `() => void` | Reset to initial values — clears URL and calls `onReset` |
+| `getActiveFilterCount` | `() => number` | Count of filters with non-empty values |
+| `hasActiveFilters` | `boolean` | `true` if any filter has a non-empty value |
+
+### URL Sync
+
+When `syncWithUrl` is `true` (the default):
+
+- On mount, filter state is initialized from URL search params if present — keys not in `initialFilters` are ignored
+- `submitFilters()` writes non-empty filters to the URL
+- `resetFilters()` clears the URL search params
+
+This means if a user bookmarks `https://example.com/users?name=Alice&gender=female` and reopens it, the filter form will be pre-populated and the table will show filtered results (if you call `onSubmit` or fetch data on mount).
+
+Disable URL sync when you don't want filters in the URL:
+
+```tsx
+useFilters({ initialFilters, syncWithUrl: false });
+```
+
+### TypeScript
+
+Types are inferred automatically from `initialFilters`:
+
+```tsx
+const initialFilters = { status: '', search: '', page: 1 };
+
+// filters is typed as { status: string; search: string; page: number }
+const { filters, changeFilters } = useFilters({ initialFilters });
+
+// TypeScript error: 'unknown' is not a key of initialFilters
+changeFilters('unknown', 'value');
+```
+
+You can also import the types:
+
+```tsx
+import useFilters, { UseFiltersReturn, UseFiltersOptions } from 'react-hook-filters';
 ```
 
 ## License
 
-[MIT](https://choosealicense.com/licenses/mit/)
+[MIT](./LICENSE)

--- a/package.json
+++ b/package.json
@@ -1,14 +1,17 @@
 {
-  "version": "0.1.0",
+  "name": "react-hook-filters",
+  "version": "1.0.0",
+  "description": "Headless React hook for managing filter state in dashboards and tables, with optional URL sync",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
+  "module": "dist/react-hook-filters.esm.js",
   "files": [
     "dist",
     "src"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "scripts": {
     "start": "tsdx watch",
@@ -33,7 +36,6 @@
     "singleQuote": true,
     "trailingComma": "es5"
   },
-  "name": "react-hook-filters",
   "author": {
     "name": "Basem Elsisy",
     "email": "basemsisy@gmail.com"
@@ -47,9 +49,12 @@
     "react",
     "hooks",
     "filters",
-    "forms"
+    "table",
+    "dashboard",
+    "url-sync",
+    "search-params",
+    "headless"
   ],
-  "module": "dist/react-hook-filters.esm.js",
   "size-limit": [
     {
       "path": "dist/react-hook-filters.cjs.production.min.js",
@@ -62,18 +67,19 @@
   ],
   "devDependencies": {
     "@size-limit/preset-small-lib": "^4.10.2",
+    "@testing-library/react-hooks": "^8.0.1",
     "@types/react": "^17.0.4",
     "@types/react-dom": "^17.0.3",
     "husky": "^6.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-test-renderer": "^17.0.2",
     "size-limit": "^4.10.2",
     "tsdx": "^0.14.1",
     "tslib": "^2.2.0",
     "typescript": "^4.2.4"
   },
   "dependencies": {
-    "history": "^5.0.0",
-    "query-string": "^7.0.0"
+    "history": "^5.0.0"
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,1 +1,2 @@
-export { default } from './useFilters'
+export { default } from './useFilters';
+export type { FilterValue, FiltersRecord, UseFiltersReturn } from './useFilters';

--- a/src/useFilters.tsx
+++ b/src/useFilters.tsx
@@ -1,45 +1,108 @@
 import * as React from 'react';
 import history from 'history/browser';
-import qs from 'query-string';
 
-type ReturnType = {
-  filters: any;
-  changeFilters: (name: string, value: any) => void;
+export type FilterValue = string | number | boolean | undefined | null;
+export type FiltersRecord = Record<string, FilterValue>;
+
+export type UseFiltersOptions<T extends FiltersRecord> = {
+  initialFilters: T;
+  syncWithUrl?: boolean;
+  onSubmit?: (filters: T) => void;
+  onReset?: (filters: T) => void;
+};
+
+export type UseFiltersReturn<T extends FiltersRecord> = {
+  filters: T;
+  changeFilters: (name: keyof T, value: FilterValue) => void;
+  setMultipleFilters: (partialFilters: Partial<T>) => void;
   resetFilters: () => void;
   submitFilters: () => void;
-}
+  getActiveFilterCount: () => number;
+  hasActiveFilters: boolean;
+};
 
-const useFilters = ({ initialFilters }: { initialFilters: any }): ReturnType => {
-
-  const searchParams = new URLSearchParams();
-
-  const { search } = history.location;
-
-  const [filters, setFilters] = React.useState(search ? qs.parse(search) : initialFilters);
-
-
-  const changeFilters = (name: keyof typeof initialFilters, value: any) => {
-    setFilters((prevFilters: any) => ({ ...prevFilters, [name]: value }));
-  };
-
-  const resetFilters = () => {
-    setFilters(initialFilters);
-    history.push({ search: undefined });
-  };
-
-  const submitFilters = () => {
-    Object.keys(filters).map(key => {
-      if (filters[key]) searchParams.append(key, filters[key]);
+function useFilters<T extends FiltersRecord>({
+  initialFilters,
+  syncWithUrl = true,
+  onSubmit,
+  onReset,
+}: UseFiltersOptions<T>): UseFiltersReturn<T> {
+  const [filters, setFilters] = React.useState<T>(() => {
+    if (!syncWithUrl) return initialFilters;
+    const search = history.location.search;
+    if (!search) return initialFilters;
+    const params = new URLSearchParams(search);
+    const parsed: Partial<T> = {};
+    params.forEach((value, key) => {
+      if (key in initialFilters) {
+        parsed[key as keyof T] = value as T[keyof T];
+      }
     });
-    history.push({ search: searchParams.toString() });
-  };
+    return { ...initialFilters, ...parsed };
+  });
+
+  const initialFiltersRef = React.useRef(initialFilters);
+  const filtersRef = React.useRef(filters);
+  filtersRef.current = filters;
+
+  const changeFilters = React.useCallback(
+    (name: keyof T, value: FilterValue) => {
+      setFilters(prev => ({ ...prev, [name]: value }));
+    },
+    []
+  );
+
+  const setMultipleFilters = React.useCallback(
+    (partialFilters: Partial<T>) => {
+      setFilters(prev => ({ ...prev, ...partialFilters }));
+    },
+    []
+  );
+
+  const resetFilters = React.useCallback(() => {
+    const initial = initialFiltersRef.current;
+    setFilters(initial);
+    if (syncWithUrl) {
+      history.push({ search: '' });
+    }
+    onReset?.(initial);
+  }, [syncWithUrl, onReset]);
+
+  const submitFilters = React.useCallback(() => {
+    const current = filtersRef.current;
+    if (syncWithUrl) {
+      const searchParams = new URLSearchParams();
+      Object.entries(current).forEach(([key, value]) => {
+        if (value !== undefined && value !== null && value !== '') {
+          searchParams.append(key, String(value));
+        }
+      });
+      history.push({ search: searchParams.toString() });
+    }
+    onSubmit?.(current);
+  }, [syncWithUrl, onSubmit]);
+
+  const getActiveFilterCount = React.useCallback(() => {
+    return Object.values(filtersRef.current).filter(
+      value => value !== undefined && value !== null && value !== ''
+    ).length;
+  }, []);
+
+  const hasActiveFilters = React.useMemo(() => {
+    return Object.values(filters).some(
+      value => value !== undefined && value !== null && value !== ''
+    );
+  }, [filters]);
 
   return {
     filters,
     changeFilters,
+    setMultipleFilters,
     resetFilters,
     submitFilters,
-  }
-};
+    getActiveFilterCount,
+    hasActiveFilters,
+  };
+}
 
 export default useFilters;

--- a/test/useFilters.test.tsx
+++ b/test/useFilters.test.tsx
@@ -1,0 +1,284 @@
+const mockPush = jest.fn();
+let mockSearch = '';
+
+jest.mock('history/browser', () => ({
+  __esModule: true,
+  default: {
+    get location() {
+      return { search: mockSearch };
+    },
+    push: (loc: { search?: string }) => {
+      mockSearch = loc.search ?? '';
+      mockPush(loc);
+    },
+  },
+}));
+
+import { renderHook, act } from '@testing-library/react-hooks';
+import useFilters from '../src';
+
+const initialFilters = { name: '', age: '', gender: '' };
+
+describe('useFilters', () => {
+  beforeEach(() => {
+    mockSearch = '';
+    mockPush.mockClear();
+  });
+
+  describe('initialization', () => {
+    it('initializes with default filters when no search params', () => {
+      const { result } = renderHook(() => useFilters({ initialFilters }));
+      expect(result.current.filters).toEqual(initialFilters);
+    });
+
+    it('initializes from URL search params when syncWithUrl is true', () => {
+      mockSearch = '?name=John&age=30';
+      const { result } = renderHook(() => useFilters({ initialFilters }));
+      expect(result.current.filters.name).toBe('John');
+      expect(result.current.filters.age).toBe('30');
+      expect(result.current.filters.gender).toBe('');
+    });
+
+    it('ignores URL params for keys not in initialFilters', () => {
+      mockSearch = '?name=John&unknown=value';
+      const { result } = renderHook(() => useFilters({ initialFilters }));
+      expect(result.current.filters.name).toBe('John');
+      expect((result.current.filters as any).unknown).toBeUndefined();
+    });
+
+    it('ignores URL params when syncWithUrl is false', () => {
+      mockSearch = '?name=John&age=30';
+      const { result } = renderHook(() =>
+        useFilters({ initialFilters, syncWithUrl: false })
+      );
+      expect(result.current.filters).toEqual(initialFilters);
+    });
+  });
+
+  describe('changeFilters', () => {
+    it('updates a single filter value', () => {
+      const { result } = renderHook(() => useFilters({ initialFilters }));
+      act(() => {
+        result.current.changeFilters('name', 'Alice');
+      });
+      expect(result.current.filters.name).toBe('Alice');
+      expect(result.current.filters.age).toBe('');
+    });
+
+    it('does not affect other filters when changing one', () => {
+      const { result } = renderHook(() => useFilters({ initialFilters }));
+      act(() => {
+        result.current.changeFilters('name', 'Alice');
+        result.current.changeFilters('age', '25');
+      });
+      expect(result.current.filters.name).toBe('Alice');
+      expect(result.current.filters.age).toBe('25');
+      expect(result.current.filters.gender).toBe('');
+    });
+  });
+
+  describe('setMultipleFilters', () => {
+    it('updates multiple filters at once', () => {
+      const { result } = renderHook(() => useFilters({ initialFilters }));
+      act(() => {
+        result.current.setMultipleFilters({ name: 'Bob', age: '25' });
+      });
+      expect(result.current.filters.name).toBe('Bob');
+      expect(result.current.filters.age).toBe('25');
+      expect(result.current.filters.gender).toBe('');
+    });
+
+    it('merges partial updates with existing filter state', () => {
+      const { result } = renderHook(() => useFilters({ initialFilters }));
+      act(() => {
+        result.current.changeFilters('gender', 'female');
+      });
+      act(() => {
+        result.current.setMultipleFilters({ name: 'Carol' });
+      });
+      expect(result.current.filters.gender).toBe('female');
+      expect(result.current.filters.name).toBe('Carol');
+    });
+  });
+
+  describe('resetFilters', () => {
+    it('resets filters to initial values', () => {
+      const { result } = renderHook(() => useFilters({ initialFilters }));
+      act(() => {
+        result.current.changeFilters('name', 'Alice');
+        result.current.changeFilters('age', '30');
+      });
+      act(() => {
+        result.current.resetFilters();
+      });
+      expect(result.current.filters).toEqual(initialFilters);
+    });
+
+    it('clears URL search params when syncWithUrl is true', () => {
+      const { result } = renderHook(() => useFilters({ initialFilters }));
+      act(() => {
+        result.current.resetFilters();
+      });
+      expect(mockPush).toHaveBeenCalledWith({ search: '' });
+    });
+
+    it('does not push to history when syncWithUrl is false', () => {
+      const { result } = renderHook(() =>
+        useFilters({ initialFilters, syncWithUrl: false })
+      );
+      act(() => {
+        result.current.resetFilters();
+      });
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    it('calls onReset callback with initial filters', () => {
+      const onReset = jest.fn();
+      const { result } = renderHook(() =>
+        useFilters({ initialFilters, onReset })
+      );
+      act(() => {
+        result.current.changeFilters('name', 'Alice');
+      });
+      act(() => {
+        result.current.resetFilters();
+      });
+      expect(onReset).toHaveBeenCalledWith(initialFilters);
+    });
+  });
+
+  describe('submitFilters', () => {
+    it('pushes active filters to URL as search params', () => {
+      const { result } = renderHook(() => useFilters({ initialFilters }));
+      act(() => {
+        result.current.changeFilters('name', 'Alice');
+        result.current.changeFilters('gender', 'female');
+      });
+      act(() => {
+        result.current.submitFilters();
+      });
+      expect(mockPush).toHaveBeenCalled();
+      const params = new URLSearchParams(mockPush.mock.calls[0][0].search);
+      expect(params.get('name')).toBe('Alice');
+      expect(params.get('gender')).toBe('female');
+    });
+
+    it('excludes empty, null, and undefined values from URL', () => {
+      const { result } = renderHook(() => useFilters({ initialFilters }));
+      act(() => {
+        result.current.submitFilters();
+      });
+      const params = new URLSearchParams(mockPush.mock.calls[0][0].search);
+      expect(params.has('name')).toBe(false);
+      expect(params.has('age')).toBe(false);
+      expect(params.has('gender')).toBe(false);
+    });
+
+    it('does not push to history when syncWithUrl is false', () => {
+      const { result } = renderHook(() =>
+        useFilters({ initialFilters, syncWithUrl: false })
+      );
+      act(() => {
+        result.current.changeFilters('name', 'Alice');
+      });
+      act(() => {
+        result.current.submitFilters();
+      });
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    it('calls onSubmit callback with current filters', () => {
+      const onSubmit = jest.fn();
+      const { result } = renderHook(() =>
+        useFilters({ initialFilters, onSubmit })
+      );
+      act(() => {
+        result.current.changeFilters('name', 'Alice');
+      });
+      act(() => {
+        result.current.submitFilters();
+      });
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'Alice' })
+      );
+    });
+  });
+
+  describe('getActiveFilterCount', () => {
+    it('returns 0 when no filters are active', () => {
+      const { result } = renderHook(() => useFilters({ initialFilters }));
+      expect(result.current.getActiveFilterCount()).toBe(0);
+    });
+
+    it('returns correct count as filters are applied', () => {
+      const { result } = renderHook(() => useFilters({ initialFilters }));
+      act(() => {
+        result.current.changeFilters('name', 'Alice');
+      });
+      expect(result.current.getActiveFilterCount()).toBe(1);
+      act(() => {
+        result.current.changeFilters('age', '25');
+      });
+      expect(result.current.getActiveFilterCount()).toBe(2);
+    });
+
+    it('decreases count when a filter is cleared', () => {
+      const { result } = renderHook(() => useFilters({ initialFilters }));
+      act(() => {
+        result.current.changeFilters('name', 'Alice');
+        result.current.changeFilters('age', '25');
+      });
+      act(() => {
+        result.current.changeFilters('name', '');
+      });
+      expect(result.current.getActiveFilterCount()).toBe(1);
+    });
+  });
+
+  describe('hasActiveFilters', () => {
+    it('is false when all filters are empty', () => {
+      const { result } = renderHook(() => useFilters({ initialFilters }));
+      expect(result.current.hasActiveFilters).toBe(false);
+    });
+
+    it('is true when at least one filter has a value', () => {
+      const { result } = renderHook(() => useFilters({ initialFilters }));
+      act(() => {
+        result.current.changeFilters('name', 'Alice');
+      });
+      expect(result.current.hasActiveFilters).toBe(true);
+    });
+
+    it('returns to false after resetFilters', () => {
+      const { result } = renderHook(() => useFilters({ initialFilters }));
+      act(() => {
+        result.current.changeFilters('name', 'Alice');
+      });
+      act(() => {
+        result.current.resetFilters();
+      });
+      expect(result.current.hasActiveFilters).toBe(false);
+    });
+  });
+
+  describe('stable references', () => {
+    it('provides stable function references across re-renders', () => {
+      const { result, rerender } = renderHook(() =>
+        useFilters({ initialFilters })
+      );
+      const {
+        changeFilters,
+        setMultipleFilters,
+        resetFilters,
+        submitFilters,
+        getActiveFilterCount,
+      } = result.current;
+      rerender();
+      expect(result.current.changeFilters).toBe(changeFilters);
+      expect(result.current.setMultipleFilters).toBe(setMultipleFilters);
+      expect(result.current.resetFilters).toBe(resetFilters);
+      expect(result.current.submitFilters).toBe(submitFilters);
+      expect(result.current.getActiveFilterCount).toBe(getActiveFilterCount);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -872,6 +872,11 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.5":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.6.tgz#d267a43cb1836dc4d182cce93ae75ba954ef6d2b"
+  integrity sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==
+
 "@babel/template@^7.12.13", "@babel/template@^7.3.3":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
@@ -1221,6 +1226,14 @@
     style-loader "^2.0.0"
     webpack "^4.44.1"
     webpack-bundle-analyzer "^4.4.0"
+
+"@testing-library/react-hooks@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
+  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    react-error-boundary "^3.1.0"
 
 "@types/babel__core@^7.1.7":
   version "7.1.14"
@@ -3802,11 +3815,6 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
-
-filter-obj@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
-  integrity sha1-mzERErxsYSehbgFsbF1/GeCAXFs=
 
 find-cache-dir@^2.1.0:
   version "2.1.0"
@@ -6807,16 +6815,6 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-query-string@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.0.0.tgz#aaad2c8d5c6a6d0c6afada877fecbd56af79e609"
-  integrity sha512-Iy7moLybliR5ZgrK/1R3vjrXq03S13Vz4Rbm5Jg3EFq1LUmQppto0qtXz4vqZ386MSRjZgnTSZ9QC+NZOSd/XA==
-  dependencies:
-    decode-uri-component "^0.2.0"
-    filter-obj "^1.1.0"
-    split-on-first "^1.0.0"
-    strict-uri-encode "^2.0.0"
-
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -6856,10 +6854,45 @@ react-dom@^17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-is@^16.12.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+"react-is@^16.12.0 || ^17.0.0 || ^18.0.0":
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
+
+react-is@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-shallow-renderer@^16.13.1:
+  version "16.15.0"
+  resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz#48fb2cf9b23d23cde96708fe5273a7d3446f4457"
+  integrity sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==
+  dependencies:
+    object-assign "^4.1.1"
+    react-is "^16.12.0 || ^17.0.0 || ^18.0.0"
+
+react-test-renderer@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-17.0.2.tgz#4cd4ae5ef1ad5670fc0ef776e8cc7e1231d9866c"
+  integrity sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==
+  dependencies:
+    object-assign "^4.1.1"
+    react-is "^17.0.2"
+    react-shallow-renderer "^16.13.1"
+    scheduler "^0.20.2"
 
 react@^17.0.2:
   version "17.0.2"
@@ -7646,11 +7679,6 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz#e9c18a410e5ed7e12442a549fbd8afa767038d65"
   integrity sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==
 
-split-on-first@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
-  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
-
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -7741,11 +7769,6 @@ stream-shift@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
-
-strict-uri-encode@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
-  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
- Fix TypeScript types: replace `any` with proper generics inferred from initialFilters shape; export FilterValue, FiltersRecord, UseFiltersOptions, UseFiltersReturn for consumers
- Fix resetFilters: pass empty string instead of undefined to history.push
- Fix submitFilters: create URLSearchParams inside the callback (not at hook root), use forEach instead of map for side-effect iteration
- Remove query-string dependency; use native URLSearchParams throughout
- Add useCallback + ref pattern so all returned functions have stable references
- Add setMultipleFilters: update several filters in one state update
- Add hasActiveFilters: boolean derived value for conditional UI
- Add getActiveFilterCount: count of non-empty filter values
- Add syncWithUrl option (default true) to opt out of URL synchronisation
- Add onSubmit / onReset callbacks for triggering data fetches
- Add 23-test suite covering all features (initialization, URL sync, callbacks, stable references)
- Update README: fix package name typo, document full API with option/return tables
- Add .npmignore to exclude test/ and config files from published package
- Bump version to 1.0.0, add description, add headless/url-sync keywords

https://claude.ai/code/session_01S2V8asxyovGQa6WuJszTZD